### PR TITLE
Add ingest-monitors to support CRON

### DIFF
--- a/sentry/Chart.yaml
+++ b/sentry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentry
 description: A Helm chart for Kubernetes
 type: application
-version: 19.1.0
+version: 19.1.1
 appVersion: 23.5.0
 dependencies:
   - name: memcached

--- a/sentry/templates/deployment-sentry-ingest-monitors.yaml
+++ b/sentry/templates/deployment-sentry-ingest-monitors.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sentry.fullname" . }}-ingest-monitors
+  labels:
+    app: {{ template "sentry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Helm"
+  {{- if .Values.asHook }}
+  {{- /* Add the Helm annotations so that deployment after asHook from true to false works */}}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "10"
+  {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ template "sentry.fullname" . }}
+      release: "{{ .Release.Name }}"
+      role: ingest-monitors
+{{- if not .Values.sentry.ingestMonitors.autoscaling.enabled }}
+  replicas: {{ .Values.sentry.ingestMonitors.replicas }}
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/configYml: {{ .Values.config.configYml | toYaml | toString | sha256sum }}
+        checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/config.yaml: {{ include (print $.Template.BasePath "/configmap-sentry.yaml") . | sha256sum }}
+        {{- if .Values.sentry.ingestMonitors.annotations }}
+{{ toYaml .Values.sentry.ingestMonitors.annotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "sentry.fullname" . }}
+        release: "{{ .Release.Name }}"
+        role: ingest-monitors
+        {{- if .Values.sentry.ingestMonitors.podLabels }}
+{{ toYaml .Values.sentry.ingestMonitors.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+      {{- if .Values.sentry.ingestMonitors.affinity }}
+{{ toYaml .Values.sentry.ingestMonitors.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.ingestMonitors.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.sentry.ingestMonitors.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.ingestMonitors.tolerations }}
+      tolerations:
+{{ toYaml .Values.sentry.ingestMonitors.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.images.sentry.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.images.sentry.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      {{- if .Values.sentry.ingestMonitors.securityContext }}
+      securityContext:
+{{ toYaml .Values.sentry.ingestMonitors.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}-ingest-monitors
+        image: "{{ template "sentry.image" . }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.images.sentry.pullPolicy }}
+        command: ["sentry"]
+        args:
+          - "run"
+          - "ingest-monitors"
+        env:
+        - name: C_FORCE_ROOT
+          value: "true"
+{{ include "sentry.env" . | indent 8 }}
+{{- if .Values.sentry.ingestMonitors.env }}
+{{ toYaml .Values.sentry.ingestMonitors.env | indent 8 }}
+{{- end }}
+        volumeMounts:
+        - mountPath: /etc/sentry
+          name: config
+          readOnly: true
+        - mountPath: {{ .Values.filestore.filesystem.path }}
+          name: sentry-data
+        {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+        - name: sentry-google-cloud-key
+          mountPath: /var/run/secrets/google
+        {{ end }}
+{{- if .Values.sentry.ingestMonitors.volumeMounts }}
+{{ toYaml .Values.sentry.ingestMonitors.volumeMounts | indent 8 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.sentry.ingestMonitors.resources | indent 12 }}
+{{- if .Values.sentry.ingestMonitors.sidecars }}
+{{ toYaml .Values.sentry.ingestMonitors.sidecars | indent 6 }}
+{{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-ingest-monitors
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "sentry.fullname" . }}-sentry
+      - name: sentry-data
+      {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled (.Values.filestore.filesystem.persistence.persistentWorkers) }}
+      {{- if .Values.filestore.filesystem.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim }}
+      {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "sentry.fullname" . }}-data
+      {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+      {{- if and (eq .Values.filestore.backend "gcs") .Values.filestore.gcs.secretName }}
+      - name: sentry-google-cloud-key
+        secret:
+          secretName: {{ .Values.filestore.gcs.secretName }}
+      {{ end }}
+{{- if .Values.sentry.ingestMonitors.volumes }}
+{{ toYaml .Values.sentry.ingestMonitors.volumes | indent 6 }}
+{{- end }}
+      {{- if .Values.sentry.ingestMonitors.priorityClassName }}
+      priorityClassName: "{{ .Values.sentry.ingestMonitors.priorityClassName }}"
+      {{- end }}

--- a/sentry/templates/serviceaccount-sentry-ingest-monitors.yaml
+++ b/sentry/templates/serviceaccount-sentry-ingest-monitors.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}-ingest-monitors
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/sentry/values.yaml
+++ b/sentry/values.yaml
@@ -257,6 +257,30 @@ sentry:
     #   - mountPath: /dev/shm
     #     name: dshm
 
+  ingestMonitors:
+    replicas: 1
+    env: []
+    resources: {}
+    affinity: {}
+    nodeSelector: {}
+    securityContext: {}
+    # tolerations: []
+    # podLabels: []
+
+    # it's better to use prometheus adapter and scale based on
+    # the size of the rabbitmq queue
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 50
+    sidecars: []
+    volumes: []
+
+    # volumeMounts:
+    #   - mountPath: /dev/shm
+    #     name: dshm
+
   billingMetricsConsumer:
     replicas: 1
     # concurrency: 4


### PR DESCRIPTION
The sentry chart is missing `ingest-monitors`, which causes some Cron configurations to silently not work. This PR adds the missing deployment.

Resolves https://github.com/getsentry/sentry/issues/49901

Also opened a PR in upstream: https://github.com/sentry-kubernetes/charts/pull/897