### PR TITLE
Add option to specify arbitrary environment variables

### DIFF
--- a/sentry-kubernetes/README.md
+++ b/sentry-kubernetes/README.md
@@ -25,3 +25,14 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                            |
 | `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
 | `priorityClassName`     | pod priorityClassName                                                                                                       | Empty                         |
+| `extraEnv`              | Additional environment variables to be added to the deployment. Can be specified multiple times.                            | `[]`                          |
+
+Each entry in the `extraEnv` array should be a key-value pair, for example:
+
+```yaml
+extraEnv:
+  - name: LOG_LEVEL
+    value: "info"
+  - name: DEBUG
+    value: "false"
+```

--- a/sentry-kubernetes/templates/deployment.yaml
+++ b/sentry-kubernetes/templates/deployment.yaml
@@ -47,6 +47,12 @@ spec:
           - name: LOG_LEVEL
             value: {{ .Values.sentry.logLevel }}
           {{ end }}
+          {{- if .Values.extraEnv }}
+          {{- range .Values.extraEnv }}
+          - name: {{ .name }}
+            value: {{ .value }}
+          {{- end }}
+          {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}
@@ -58,3 +64,4 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
       serviceAccountName: {{ template "sentry-kubernetes.serviceAccountName" . }}
+

--- a/sentry-kubernetes/values.yaml
+++ b/sentry-kubernetes/values.yaml
@@ -33,3 +33,6 @@ rbac:
 
 podLabels: {}
 podAnnotations: {}
+
+# Additional environment variables
+extraEnv: []


### PR DESCRIPTION
Resolves #2

This pull request introduces the ability to specify arbitrary environment variables in the `sentry-kubernetes` Helm chart, enhancing its configurability and flexibility for users.

- **Updates `deployment.yaml`**: Implements a logic to iterate over user-defined environment variables specified under `.Values.extraEnv` and adds them to the container's `env` list. This allows users to pass custom environment variables to the `sentry-kubernetes` deployment.
- **Modifies `values.yaml`**: Adds a new section `extraEnv` where users can define additional environment variables as a list of name/value pairs. This section is initially set to an empty array, indicating that no extra environment variables are defined by default.
- **Enhances `README.md`**: Updates the documentation to include instructions on how to use the new `extraEnv` parameter for adding custom environment variables. This addition ensures users are aware of how to leverage the new feature for their specific needs.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WATonomous/sentry-kubernetes-charts/issues/2?shareId=631566e2-069d-4a2e-ad76-05c8c89b3ad1).